### PR TITLE
Upgraded Terraform null provider to v3.2.0

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,7 +10,7 @@ locals {
 terraform {
   required_providers {
     aws  = ">= 3.0"
-    null = "~> 2.1"
+    null = "~> 3.2"
   }
 }
 


### PR DESCRIPTION
This is to support deployments of forge (via cumulus-tf) on ARM-based Macs